### PR TITLE
Add docker-py to pip requirements for nose-locust

### DIFF
--- a/nose-locust/requirements.txt
+++ b/nose-locust/requirements.txt
@@ -6,4 +6,4 @@ pyzmq==14.6.0
 requests[security]==2.6.0
 fabric==1.10.1
 flaky==1.1.0
-docker-py>=1.3.0
+docker-py==1.3.0

--- a/nose-locust/requirements.txt
+++ b/nose-locust/requirements.txt
@@ -6,3 +6,4 @@ pyzmq==14.6.0
 requests[security]==2.6.0
 fabric==1.10.1
 flaky==1.1.0
+docker-py>=1.3.0


### PR DESCRIPTION
- Needed for Hub-breaker
- Testing performed: Verified docker build executes successfully; verified can start python and import docker python bindings within running container.
